### PR TITLE
fix: solve issue with attribute not being escaped correctly

### DIFF
--- a/widgets/elementor/pricing-table.php
+++ b/widgets/elementor/pricing-table.php
@@ -1016,7 +1016,7 @@ class Pricing_Table extends Widget_Base {
 //		$this->add_render_attribute( 'button_icon', 'class', $settings['button_icon'] );
 		$this->add_render_attribute( 'button_icon_align', 'class', 'obfx-button-icon-align-' . $settings['button_icon_align'] );
 		if ( ! empty( $settings['button_link']['url'] ) ) {
-			$this->add_render_attribute( 'button', 'href', $settings['button_link']['url'] );
+			$this->add_render_attribute( 'button', 'href', esc_url( $settings['button_link']['url'] ) );
 
 			if ( ! empty( $settings['button_link']['is_external'] ) ) {
 				$this->add_render_attribute( 'button', 'target', '_blank' );


### PR DESCRIPTION
### Summary

Properly escape url for pricing table widget.
Once merged a new version of OBFX must be released with the dependency updated.

Close: Codeinwp/themeisle#1617