### PR TITLE
fix: improper tag sanitization

### DIFF
--- a/class-elementor-extra-widgets.php
+++ b/class-elementor-extra-widgets.php
@@ -81,7 +81,7 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 			foreach ( $elements_data as &$element ) {
 				if ( isset( $element['elType'] ) && $element['elType'] === 'widget' ) {
 					// Check if the widget is of the desired type
-					if ( isset( $element['widgetType'] ) && in_array( $element['widgetType'], [ 'obfx-pricing-table' ] ) ) {
+					if ( isset( $element['widgetType'] ) && in_array( $element['widgetType'], [ 'obfx-pricing-table', 'obfx-posts-grid' ] ) ) {
 						// Modify the settings of the widget
 						$settings = $element['settings'];
 						if ( isset( $settings['title_tag'] ) ) {
@@ -89,6 +89,9 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 						}
 						if ( isset( $settings['subtitle_tag'] ) ) {
 							$settings['subtitle_tag'] = $this->sanitize_title_attributes( $settings['subtitle_tag'], 'p' );
+						}
+						if ( isset( $settings['grid_title_tag'] ) ) {
+							$settings['grid_title_tag'] = $this->sanitize_title_attributes( $settings['grid_title_tag'], 'h3' );
 						}
 						$element['settings'] = $settings;
 					}
@@ -174,6 +177,7 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 		 */
 		public function add_elementor_widgets( $widgets_manager ) {
 			$elementor_widgets = $this->get_dir_files( __DIR__ . '/widgets/elementor' );
+			include_once( plugin_dir_path( __FILE__ ) . 'widgets/elementor/traits/sanitization.php' );
 
 			foreach ( $elementor_widgets as $widget ) {
 				require_once $widget;

--- a/widgets/elementor/posts-grid.php
+++ b/widgets/elementor/posts-grid.php
@@ -17,6 +17,7 @@ use Elementor\Group_Control_Typography;
 use Elementor\Core\Schemes\Color;
 use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
+use ThemeIsle\ElementorExtraWidgets\Traits\Sanitization;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -28,6 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package ThemeIsle\ElementorExtraWidgets
  */
 class Posts_Grid extends Widget_Base {
+	use Sanitization;
 
 	/**
 	 * Widget title.
@@ -1632,8 +1634,10 @@ class Posts_Grid extends Widget_Base {
 	protected function renderTitle() {
 		$settings = $this->get_settings();
 
-		if ( $settings['grid_title_hide'] !== 'yes' ) { ?>
-			<<?php echo $settings['grid_title_tag']; ?> class="entry-title obfx-grid-title">
+		if ( $settings['grid_title_hide'] !== 'yes' ) {
+			$grid_title_tag = $this->sanitize_tag( $settings['grid_title_tag'], 'h3' );
+            ?>
+			<<?php echo $grid_title_tag; ?> class="entry-title obfx-grid-title">
 			<?php if ( $settings['grid_title_link'] == 'yes' ) { ?>
 				<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>">
 					<?php the_title(); ?>
@@ -1642,7 +1646,7 @@ class Posts_Grid extends Widget_Base {
 			} else {
 				the_title();
 			} ?>
-			</<?php echo $settings['grid_title_tag']; ?>>
+			</<?php echo $grid_title_tag; ?>>
 			<?php
 		}
 	}

--- a/widgets/elementor/pricing-table.php
+++ b/widgets/elementor/pricing-table.php
@@ -18,6 +18,7 @@ use Elementor\Core\Schemes\Color;
 use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
+use ThemeIsle\ElementorExtraWidgets\Traits\Sanitization;
 
 /**
  * Class Pricing_Table
@@ -25,6 +26,7 @@ use Elementor\Repeater;
  * @package ThemeIsle\ElementorExtraWidgets
  */
 class Pricing_Table extends Widget_Base {
+	use Sanitization;
 
 	/**
 	 * Widget title.
@@ -1002,19 +1004,6 @@ class Pricing_Table extends Widget_Base {
 		$this->end_controls_tab();
 
 		$this->end_controls_tabs();
-	}
-
-	/**
-	 * Sanitize tag output to only the allowed values.
-	 *
-	 * @param string $tag     Tag to sanitize.
-	 * @param string $default Default tag. Defaults to 'p'.
-	 *
-	 * @return string
-	 */
-	private function sanitize_tag( $tag, $default = 'p' ) {
-		$allowed_tags = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ];
-		return in_array( $tag, $allowed_tags ) ? $tag : $default;
 	}
 
 	/**

--- a/widgets/elementor/traits/sanitization.php
+++ b/widgets/elementor/traits/sanitization.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Sanitization functions for Elementor builder
+ *
+ * @link       https://themeisle.com
+ * @since      1.0.0
+ *
+ * @package    ThemeIsle\ElementorExtraWidgets
+ */
+namespace ThemeIsle\ElementorExtraWidgets\Traits;
+
+trait Sanitization {
+	/**
+	 * Sanitize tag output to only the allowed values.
+	 *
+	 * @param string $tag     Tag to sanitize.
+	 * @param string $default Default tag. Defaults to 'p'.
+	 *
+	 * @return string
+	 */
+	private function sanitize_tag( $tag, $default = 'p' ) {
+		$allowed_tags = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ];
+		return in_array( $tag, $allowed_tags ) ? $tag : $default;
+	}
+}


### PR DESCRIPTION
Solves issue for Orbit Fox where the title tag of the widget is not sanitized
Reworked code so that it will reuse previously added sanitization.
After merging to `master`, OBFX needs a dependency update.

References: Codeinwp/themeisle#1626