### PR TITLE
fix: grid columns not properly sanitized

### DIFF
--- a/class-elementor-extra-widgets.php
+++ b/class-elementor-extra-widgets.php
@@ -11,10 +11,14 @@
 namespace ThemeIsle;
 
 use Elementor\Plugin;
+use ThemeIsle\ElementorExtraWidgets\Traits\Sanitization;
 
 if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 
+	include_once( plugin_dir_path( __FILE__ ) . 'widgets/elementor/traits/sanitization.php' );
+
 	class ElementorExtraWidgets {
+		use Sanitization;
 		/**
 		 * @var ElementorExtraWidgets
 		 */
@@ -73,6 +77,23 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 		}
 
 		/**
+		 * Sanitize grid column values.
+		 *
+		 * @param array $settings The settings to sanitize.
+		 */
+		private function sanitize_grid_columns( &$settings ) {
+			if ( isset( $settings['grid_columns'] ) ) {
+				$settings['grid_columns'] = $this->sanitize_numeric( $settings['grid_columns'], 3 );
+			}
+			if ( isset( $settings['grid_columns_tablet'] ) ) {
+				$settings['grid_columns_tablet'] = $this->sanitize_numeric( $settings['grid_columns_tablet'], 2 );
+			}
+			if ( isset( $settings['grid_columns_mobile'] ) ) {
+				$settings['grid_columns_mobile'] = $this->sanitize_numeric( $settings['grid_columns_mobile'], 1 );
+			}
+		}
+
+		/**
 		 * Recursively search and sanitize element fields data.
 		 *
 		 * @param array $elements_data The elements data.
@@ -84,6 +105,9 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 					if ( isset( $element['widgetType'] ) && in_array( $element['widgetType'], [ 'obfx-pricing-table', 'obfx-posts-grid' ] ) ) {
 						// Modify the settings of the widget
 						$settings = $element['settings'];
+
+						// Sanitize the grid columns passing the settings by reference
+						$this->sanitize_grid_columns( $settings );
 						if ( isset( $settings['title_tag'] ) ) {
 							$settings['title_tag'] = $this->sanitize_title_attributes( $settings['title_tag'], 'h3' );
 						}
@@ -177,7 +201,6 @@ if ( ! class_exists( '\ThemeIsle\ElementorExtraWidgets' ) ) {
 		 */
 		public function add_elementor_widgets( $widgets_manager ) {
 			$elementor_widgets = $this->get_dir_files( __DIR__ . '/widgets/elementor' );
-			include_once( plugin_dir_path( __FILE__ ) . 'widgets/elementor/traits/sanitization.php' );
 
 			foreach ( $elementor_widgets as $widget ) {
 				require_once $widget;

--- a/widgets/elementor/posts-grid.php
+++ b/widgets/elementor/posts-grid.php
@@ -1459,9 +1459,13 @@ class Posts_Grid extends Widget_Base {
 		// Get settings.
 		$settings = $this->get_settings();
 
+        $grid_columns_mobile = ! empty( $settings['grid_columns_mobile'] ) ? ' obfx-grid-mobile-' . $this->sanitize_numeric( $settings['grid_columns_mobile'], 1 ) : '';
+        $grid_columns_tablet = ! empty( $settings['grid_columns_tablet'] ) ? ' obfx-grid-tablet-' . $this->sanitize_numeric( $settings['grid_columns_tablet'], 2 ) : '';
+        $grid_columns = ! empty( $settings['grid_columns'] ) ? ' obfx-grid-desktop-' . $this->sanitize_numeric( $settings['grid_columns'], 3 ) : '';
+
 		// Output.
 		echo '<div class="obfx-grid">';
-		echo '<div class="obfx-grid-container' . ( ! empty( $settings['grid_style'] ) && $settings['grid_style'] == 'list' ? ' obfx-grid-style-' . $settings['grid_style'] : '' ) . ( ! empty( $settings['grid_columns_mobile'] ) ? ' obfx-grid-mobile-' . $settings['grid_columns_mobile'] : '' ) . ( ! empty( $settings['grid_columns_tablet'] ) ? ' obfx-grid-tablet-' . $settings['grid_columns_tablet'] : '' ) . ( ! empty( $settings['grid_columns'] ) ? ' obfx-grid-desktop-' . $settings['grid_columns'] : '' ) . '">';
+		echo '<div class="obfx-grid-container' . ( ! empty( $settings['grid_style'] ) && $settings['grid_style'] == 'list' ? ' obfx-grid-style-' . esc_attr( $settings['grid_style'] ) : '' ) . $grid_columns_mobile . $grid_columns_tablet . $grid_columns . '">';
 
 		// Arguments for query.
 		$args = array();

--- a/widgets/elementor/traits/sanitization.php
+++ b/widgets/elementor/traits/sanitization.php
@@ -22,4 +22,16 @@ trait Sanitization {
 		$allowed_tags = [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ];
 		return in_array( $tag, $allowed_tags ) ? $tag : $default;
 	}
+
+	/**
+	 * Sanitize a numeric value.
+	 *
+	 * @param mixed $value Value to sanitize.
+	 * @param int $default Default value. Defaults to 0.
+	 *
+	 * @return int
+	 */
+	private function sanitize_numeric( $value, $default = 0 ) {
+		return is_numeric( $value ) ? $value : $default;
+	}
 }


### PR DESCRIPTION
### Summary

Added proper sanitization on settings save and on render for grid_columns properties.
I moved the Sanitization trait so that it can be accessed also on the main class.

Closes: Codeinwp/themeisle#1633.